### PR TITLE
Added an RGB to XY and XY to RGB converter methods for LightOrchestrator

### DIFF
--- a/factfeel_client.py
+++ b/factfeel_client.py
@@ -1,12 +1,16 @@
 # imports
 from phue import Bridge
+import speech_recognition as sr
+from rgbxy import Converter
+
 from subprocess import call
 import numpy as np
-import speech_recognition as sr
+from matplotlib import pyplot as plt
+
 import serial
 import requests
 import json
-from matplotlib import pyplot as plt
+
 
 
 
@@ -15,6 +19,17 @@ class LightOrchestrator:
     def __init__(self, ip = None, lights = None, colors = None, spectrum_size = 11):
         
         self.spectrum_size = spectrum_size
+        
+        
+        ######
+        #
+        # Converter has some drift if you convert back and forth between the 
+        # xy_to_rgb and rgb_to_xy functions. This may be fixed if we find the
+        # correct Gamut for each light. Or we recommed only a limited number
+        # of calls to this function.
+        #
+        ######
+        self.converter = Converter()
         
         if ip:
             self.set_ip(ip)
@@ -46,6 +61,12 @@ class LightOrchestrator:
             if light not in self.lamp_colors:
                 raise NameError(f'Light named {light} does not exist on the Hue Bridge!')
         
+    def xy_to_rgb(self, colors):
+        return [self.converter.xy_to_rgb(x, y) for x, y in colors]
+    
+    def rgb_to_xy(self, colors):
+        return [self.converter.rgb_to_xy(r, g, b) for r, g, b in colors]    
+    
     def set_base_colors(self, fact_base, feel_base):
         self.fact_base_color = fact_base
         self.feel_base_color = feel_base

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ seaborn==0.11.2
 gunicorn==20.1.0
 beautifulsoup4==4.10.0
 nltk==3.6.6
+rgbxy==0.5


### PR DESCRIPTION
**TECH DEBT:**
Feels like this is the first time bringing in some tech debt, meaning that converter library will work for us but it has one caveat. 

Converter above works well, but only for one call for conversions. Meaning, don't call the method xy_to_rgb and then use that result to pass into rgb_to_xy. There is some drift in the values returned, so limiting the number of calls back and forth will keep it as accurate as possible. See example below:

```

light_orchestrator = LightOrchestrator()

light_orchestrator.xy_to_rgb(colors = [
    [0.3227, 0.3290], # White
    [0.643, 0.3045]   # Dark Red
    ])

Out[5]: [(254, 254, 255), (255, 69, 68)]

light_orchestrator.rgb_to_xy([(254, 254, 255), (255, 69, 68)])

Out[6]: 
[(0.322031549204704, 0.3279493014980666),
 (0.6507032445165537, 0.3085124310111578)]

```


It looks like this is partially due to the flips between Integer and Double types, or maybe some other math reason.